### PR TITLE
Add OpenCompass badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@
 </p>
 <p align="center">
    🌐 <a href="https://tigerbot.com/" target="_blank">TigerBot</a> • 🤗 <a href="https://huggingface.co/TigerResearch" target="_blank">Hugging Face</a>
+
 </p>
+<div align="center">
+
+[![evaluation](https://img.shields.io/badge/OpenCompass-Support-royalblue.svg)](https://github.com/internLM/OpenCompass/)
+
+</div>
 <h4 align="left">
     <p>
         <b>中文</b> |

--- a/README_en.md
+++ b/README_en.md
@@ -9,6 +9,11 @@
 <p align="center">
    🌐 <a href="https://tigerbot.com/" target="_blank">TigerBot</a> • 🤗 <a href="https://huggingface.co/TigerResearch" target="_blank">Hugging Face</a>
 </p>
+<div align="center">
+
+[![evaluation](https://img.shields.io/badge/OpenCompass-Support-royalblue.svg)](https://github.com/internLM/OpenCompass/)
+
+</div>
 <h4 align="left">
     <p>
         <b>English</b> |


### PR DESCRIPTION
Hi team,

Thanks for using OpenCompass! We're thrilled to see more LLM teams adopting the toolkit to evaluate models systematically. We deeply appreciate your dedication to transparency and reproducibility in LLM evaluation. Here we are wondering if you would add a badge to readme, with which visitors can quickly identify and appreciate the rigorous evaluation standards your model has undergone.

BTW, as OpenCompass continues to evolve, we welcome any evaluation requests or ideas for future collaborations. Feel free to let us know if your team needs any assistance.